### PR TITLE
make _bufferEmpty more efficient

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ class Remedian {
      * @param {number} bufferSize - size of a single buffer.
      */
   constructor(bufferSize) {
-    // TODO: check if bufferSize is an odd number
     this.bufferSize = bufferSize;
     this.buffers = [];
   }
@@ -36,15 +35,8 @@ class Remedian {
      * @param {number} position - buffer number to check.
      * @return {boolean} true if buffer is empty, false if not.
      */
-  _bufferEmpty(position) {
-    const array = this.buffers[position];
-    // TODO:
-    for (let j = 0; j < array.length; j++) {
-      if (array[j] != undefined) {
-        return false;
-      }
-    }
-    return true;
+  _bufferEmpty(position) {   
+    return this.buffers[position][0] == undefined;
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remedian",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remedian",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.15.0",


### PR DESCRIPTION
This PR improves the efficiency of _emptyBuffer function by just checking the first element of the array.