### PR TITLE
validate buffer size. fixes issue #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ class Remedian {
     if (bufferSize === undefined) {
       bufferSize = 3;
     }
+    else if (bufferSize % 2 === 0) {
+      bufferSize = 3;
+      throw new SyntaxError("Remedian buffer size must be an odd number")
+    }
     this.bufferSize = bufferSize;
 
     this.buffers = [];


### PR DESCRIPTION
## Description
Provide small data validation on user-chosen buffer size. The user is only allowed to choose odd numbers and will be presented with a SyntaxError upon choosing an even number. 

Fixes # 1

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update