### PR TITLE
Validation to enforce buffer size to be an odd number greater than or equal to 3

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ class Remedian {
   constructor(bufferSize) {
     if (bufferSize === undefined) {
       bufferSize = 3;
+    } else if (bufferSize <= 1 || bufferSize % 2 === 0) {
+      throw new Error(`Remedian buffer size must be an odd number 
+      greater or equal to 3. You provided ${bufferSize}`);
     }
     this.bufferSize = bufferSize;
 
@@ -153,7 +156,8 @@ class Remedian {
 
   /**
      * Calculate approximate median based on Remedian algorithm.
-     * @return {(number|undefined)} approximate median if, at least, one number was added.
+     * @return {(number|undefined)} approximate median if, at least,
+     * one number was added.
      */
   approximate() {
     if (this.buffers.length == 0) {

--- a/index.test.js
+++ b/index.test.js
@@ -60,12 +60,27 @@ describe('Weighted median function', () => {
   );
 });
 
-describe('Remedian algorithm implementation correctness', () => {
+describe('Buffer size correctness', () => {
   test('default buffer size is 3', () => {
     const remedian = new Remedian();
     expect(remedian.bufferSize).toEqual(3);
   });
 
+  test.each([
+    -1, 0, 1, 2, 4,
+  ])(
+      `check for error if buffer size is: %s`,
+      (value) => {
+        expect(()=>{
+          /* eslint-disable no-unused-vars */
+          const remedian = new Remedian(value);
+          /* eslint-enable no-unused-vars */
+        }).toThrowError();
+      },
+  );
+});
+
+describe('Remedian algorithm implementation correctness', () => {
   test('first buffer is created only when first number is added', () => {
     const remedian = new Remedian(3);
     expect(remedian.buffers.length).toEqual(0);
@@ -73,22 +88,24 @@ describe('Remedian algorithm implementation correctness', () => {
     expect(remedian.buffers.length).toEqual(1);
   });
 
-  test(`when current buffer is full, new buffer is created with correct median`, () => {
-    const remedian = new Remedian(3);
-    remedian.write(1);
-    remedian.write(2);
-    expect(remedian.buffers.length).toEqual(1);
-    remedian.write(3);
-    expect(remedian.buffers.length).toEqual(2);
+  test(`when current buffer is full, new buffer is created with correct median`
+      , () => {
+        const remedian = new Remedian(3);
+        remedian.write(1);
+        remedian.write(2);
+        expect(remedian.buffers.length).toEqual(1);
+        remedian.write(3);
+        expect(remedian.buffers.length).toEqual(2);
 
-    // median of (1,2,3) is 2, and should be placed in a new buffer
-    expect(remedian.buffers[1][0]).toEqual(2);
+        // median of (1,2,3) is 2, and should be placed in a new buffer
+        expect(remedian.buffers[1][0]).toEqual(2);
 
-    // returns correct median
-    expect(remedian.approximate()).toEqual(2);
-  });
+        // returns correct median
+        expect(remedian.approximate()).toEqual(2);
+      });
 
-  test(`when number of elements is not a power of buffer size, weighted median should be calculated`, () => {
+  test(`when number of elements is not a power of buffer size, weighted 
+  median should be calculated`, () => {
     const remedian = new Remedian(3);
     remedian.write(1);
     remedian.write(2);


### PR DESCRIPTION
Two scenarios are covered:

    -bufferSize is less or equal to 1, throw an error and notify users that the allowed bufferSize value must be an odd number greater or equal to 3.

    -bufferSize is above 1 and is even, throw an error that notifies the users that the allowed bufferSize value must be an odd number greater or equal to 3.

Test cases have been added for the scenarios listed above. 